### PR TITLE
Fixed the extracted environment.

### DIFF
--- a/lib/script-runner.coffee
+++ b/lib/script-runner.coffee
@@ -32,7 +32,6 @@ class ScriptRunner
       'run:terminate': (event) => @stop()
 
   fetchShellEnvironment: (callback) ->
-    console.log process.env
     # I tried using ChildProcess.execFile but there is no way to set detached and this causes the child shell to lock up. This command runs an interactive login shell and executes the export command to get a list of environment variables. We then use these to run the script:
     child = ChildProcess.spawn process.env.SHELL, ['-ilc', 'export'],
       # This is essential for interactive shells, otherwise it never finishes:
@@ -62,7 +61,6 @@ class ScriptRunner
             
           # Then add all non-empty values to the extracted environment
           environment[key] = value if key != ''
-      console.log environment
       callback(environment)
 
   killProcess: (runner, detach = false)->


### PR DESCRIPTION
The fetch environment function now discards output from login scripts and it no longer includes declare -x in the environment variable names.