### PR TITLE
Remove Windows support. For now... Sorry.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "script-runner",
   "main": "./lib/script-runner",
   "version": "1.7.1",
+  "os": "!win32",
   "description": "Runs scripts inside of Atom, just like from a terminal.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
It's probably for the best to prevent apm from installing it on windows, since execution is never going to get past fetching the shell executable.