### PR TITLE
Fix issue with 'declare -x' environment variables

### DIFF
--- a/examples/environment.coffee
+++ b/examples/environment.coffee
@@ -9,6 +9,10 @@ exportsCommand = process.env.SHELL + " -lc export"
 
 # Run the command and update the local process environment:
 ChildProcess.exec exportsCommand, (error, stdout, stderr) ->
-	for definition in stdout.trim().split('\n')
-		[key, value] = definition.split('=', 2)
-		process.env[key] = value
+  regex = new RegExp('^declare\\s-x\\s(.*?)="(.*?)"',"g")
+  for definition in stdout.trim().split('\n')
+    definition = definition.replace /^declare\s-x\s(.*?)="(.*?)"/g, (a,n,v) ->
+      v = v.replace /\\\\/g, "\\"
+      "#{n}=#{v}"
+    [key, value] = definition.split('=', 2)
+    process.env[key] = value


### PR DESCRIPTION
Bash environment variables can be in the form « declare -x NAME="VALUE" ».  This patch fixes that issue by stripping the "declare -x" prefix, stripping the surrounding quotes from the value, and replacing double backslashes with single backslashes in the value.
