### PR TITLE
Added option for specifying which way the new pane should be split.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ The default Atom process takes environment variables from the shell it was launc
 
 To ensure consistent behavior, when running a script, environment variables are extracted from the interactive login shell. This usually loads the same environment variables you'd expect when using the terminal.
 
+### Split Direction
+
+It is possible to configure which way to split the new pane. Open your Atom config file and edit `'script-runner'.splitDirection`
+
 ## Contributing
 
 1. Fork it

--- a/README.md
+++ b/README.md
@@ -46,7 +46,14 @@ To ensure consistent behavior, when running a script, environment variables are 
 
 ### Split Direction
 
-It is possible to configure which way to split the new pane. Open your Atom config file and edit `'script-runner'.splitDirection`
+It is possible to configure which way to split the new pane. Open your Atom config file and edit `'script-runner'.splitDirection`, the possible
+values are: `'up'`, `'down'`, `'left'` and `'right'`. For example:
+```cson
+"*":
+  //...
+  'script-runner':
+    `splitDirection`: `down`
+```
 
 ## Contributing
 

--- a/lib/script-runner.coffee
+++ b/lib/script-runner.coffee
@@ -19,6 +19,12 @@ class ScriptRunner
     {path: '\\.sh$', command: 'bash'}
   ]
 
+  config:
+    splitDirection:
+      type: 'string'
+      default: 'right'
+      enum: ['left', 'right', 'up', 'down']
+
   destroy: ->
     @killAllProcesses()
 
@@ -54,7 +60,12 @@ class ScriptRunner
   createRunnerView: (editor) ->
     if not @pane?
       # creates a new pane if there isn't one yet
-      @pane = atom.workspace.getActivePane().splitRight()
+      switch atom.config.get('script-runner.splitDirection')
+        when 'up' then @pane = atom.workspace.getActivePane().splitUp()
+        when 'down' then @pane = atom.workspace.getActivePane().splitDown()
+        when 'left' then @pane = atom.workspace.getActivePane().splitLeft()
+        when 'right' then @pane = atom.workspace.getActivePane().splitRight()
+      
       @pane.onDidDestroy () =>
         @killAllProcesses(true)
         @pane = null


### PR DESCRIPTION
This is a configurable alternative to PR #42 by @vswamy, he is right that some users might prefer different behaviour. It is configurable in atom's config file as documented in the readme.

I think the ultimate solution would be to create some kind of a `script-runner-container` view which would contain all the script runner views and chuck that into a [panel](https://atom.io/docs/api/v1.4.0/Panel) on the side. After some digging, I found a plugin that does something similar, [atom-commander](https://github.com/morassman/atom-commander).