### PR TITLE
Issue 57 - Execute whole unsaved buffer.

### DIFF
--- a/lib/script-runner-process.coffee
+++ b/lib/script-runner-process.coffee
@@ -64,6 +64,8 @@ class ScriptRunnerProcess
       cwd = atom.project.path
     
     callback(editor.getText(), cwd)
+    
+    return true
   
   execute: (cmd, env, editor) ->
     # Split the incoming command so we can modify it
@@ -81,7 +83,8 @@ class ScriptRunnerProcess
       args.push TempWrite.sync(text)
       @spawn args, cwd, env
     
-    return true
+    # something really has to go wrong for this.
+    return false
   
   spawn: (args, cwd, env, callback) ->
     # Spawn the child process:

--- a/lib/script-runner-process.coffee
+++ b/lib/script-runner-process.coffee
@@ -57,6 +57,14 @@ class ScriptRunnerProcess
     # Otherwise it was not handled:
     return false
   
+  resolveBuffer: (editor, callback) ->
+    if editor.getPath()
+      cwd = Path.dirname(editor.getPath())
+    else
+      cwd = atom.project.path
+    
+    callback(editor.getText(), cwd)
+  
   execute: (cmd, env, editor) ->
     # Split the incoming command so we can modify it
     args = Shellwords.split cmd
@@ -69,7 +77,10 @@ class ScriptRunnerProcess
       args.push path
       @spawn args, cwd, env
     
-    callback(editor.getText(), cwd)
+    return true if @resolveBuffer editor, (text, cwd) =>
+      args.push TempWrite.sync(text)
+      @spawn args, cwd, env
+    
     return true
   
   spawn: (args, cwd, env, callback) ->


### PR DESCRIPTION
Fix to #57 

Execute the whole buffer in case there is no selection on an unsaved file.

Also removed a call to an undefined callback function in `ScriptRunnerProcess.execute` this call was only reachable when you tried to execute an unsaved buffer with no selection.