### PR TITLE
Replace node-pty with node-pty-prebuilt.

### DIFF
--- a/lib/script-runner-process.js
+++ b/lib/script-runner-process.js
@@ -1,6 +1,6 @@
 /** @babel */
 
-const PTY = require('node-pty');
+const PTY = require('node-pty-prebuilt');
 const OS = require('os');
 const Path = require('path');
 const Shellwords = require('shellwords');

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "etch": "^0.12.0",
     "shell-environment": "^0.3.0",
     "xterm": "^3.3",
-    "node-pty": "^0.7.0",
+    "node-pty-prebuilt": "^0.7.0",
     "temp-write": "^3.4",
     "resize-observer-polyfill": "^1.4"
   }


### PR DESCRIPTION
This should fix issue #87 for most people in the interim (most likely forever) until `node-gyp` gets fixed or eradicated from the node.js ecosystem.